### PR TITLE
feat: Support a single line return for slack integration

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -30,7 +30,7 @@ func LoadArgs() (cfg Config, err error) {
 	var cmd cmdArgs
 
 	flag.Usage = func() {
-		fmt.Println("usage: gdiv [owner] [base] [head] [-pat | -pat-path] ")
+		fmt.Println("usage: gdiv [options] [owner] [base] [head] [-pat | -pat-path] ")
 		flag.PrintDefaults()
 	}
 	flag.StringVar(&cmd.patPath, "pat-path", "", "A file containing your github PAT.")
@@ -45,7 +45,7 @@ func LoadArgs() (cfg Config, err error) {
 
 	args := flag.Args()
 	if cmd.pat == "" && cmd.patPath == "" {
-		err = errors.New("Either pat or pat-path must be provided")
+		err = errors.New("either pat or pat-path must be provided")
 		flag.Usage()
 		return
 	}
@@ -54,7 +54,7 @@ func LoadArgs() (cfg Config, err error) {
 		return
 	}
 	if cmd.aheadOnly && cmd.behindOnly {
-		err = errors.New("You can only use -ahead and -behind exclusively.")
+		err = errors.New("you can only use -ahead and -behind exclusively")
 		return
 	}
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -13,17 +13,17 @@ import (
 const defaultPath = "~/.gdivpat"
 
 type cmdArgs struct {
-	pat, patPath          string
-	org, head, base       string
-	aheadOnly, behindOnly bool
-	all, help, short      bool
+	pat, patPath              string
+	org, head, base           string
+	aheadOnly, behindOnly     bool
+	all, help, short, oneLine bool
 }
 
 type Config struct {
-	GitPat                string
-	Org, Head, Base       string
-	AheadOnly, BehindOnly bool
-	ShowAll, Short        bool
+	GitPat                  string
+	Org, Head, Base         string
+	AheadOnly, BehindOnly   bool
+	ShowAll, Short, OneLine bool
 }
 
 func LoadArgs() (cfg Config, err error) {
@@ -40,6 +40,7 @@ func LoadArgs() (cfg Config, err error) {
 	flag.BoolVar(&cmd.aheadOnly, "ahead", false, "Show only the aheadBy number.")
 	flag.BoolVar(&cmd.behindOnly, "behind", false, "Show only the behindBy number.")
 	flag.BoolVar(&cmd.short, "s", false, "Show a short version of the output.")
+	flag.BoolVar(&cmd.oneLine, "o", false, "Put the output on one line with \n as breaks.")
 
 	flag.Parse()
 
@@ -67,6 +68,7 @@ func LoadArgs() (cfg Config, err error) {
 		Short:      cmd.short,
 		AheadOnly:  cmd.aheadOnly,
 		BehindOnly: cmd.behindOnly,
+		OneLine:    cmd.oneLine,
 	}
 
 	if cfg.GitPat == "" {

--- a/cmd/gdiv/main.go
+++ b/cmd/gdiv/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -50,8 +51,20 @@ func main() {
 			ch <- wd(r, diff, cfg)
 		}(r)
 	}
-	for range repos {
-		fmt.Print(<-ch)
+	if cfg.OneLine {
+		var b bytes.Buffer
+		for range repos {
+			var t = <-ch
+			if t != "" {
+				b.WriteString(t)
+				b.WriteString("\\n")
+			}
+		}
+		fmt.Print(b.String())
+	} else {
+		for range repos {
+			fmt.Print(<-ch)
+		}
 	}
 }
 
@@ -64,9 +77,9 @@ func writeDiff(repoName string, diff Diff, cfg cfg.Config) string {
 	if cfg.BehindOnly || (!cfg.AheadOnly && !cfg.BehindOnly) {
 		msg = append(msg, fmt.Sprintf("behind by %d", diff.Behind))
 	}
-	sb.WriteString(writeRow(repoName, strings.Join(msg, ", ")))
-	sb.WriteString(writeRow("", fmt.Sprintf("  %s -> %s", diff.BaseHash, diff.HeadHash)))
-	sb.WriteString(writeRow("", "  "+diff.URL))
+	sb.WriteString(writeRow(repoName, strings.Join(msg, ", "), cfg.OneLine))
+	sb.WriteString(writeRow("", fmt.Sprintf("  %s -> %s", diff.BaseHash, diff.HeadHash), cfg.OneLine))
+	sb.WriteString(writeRow("", "  "+diff.URL, cfg.OneLine))
 	return sb.String()
 }
 func writeShort(repoName string, diff Diff, cfg cfg.Config) string {
@@ -79,7 +92,8 @@ func writeShort(repoName string, diff Diff, cfg cfg.Config) string {
 		msg = append(msg, fmt.Sprintf("behind by %d", diff.Behind))
 	}
 	msg = append(msg, diff.URL)
-	sb.WriteString(writeRow(repoName, strings.Join(msg, ", ")))
+
+	sb.WriteString(writeRow(repoName, strings.Join(msg, ", "), cfg.OneLine))
 	return sb.String()
 }
 
@@ -87,7 +101,10 @@ func writeError(repoName string, err error) string {
 	return fmt.Sprintln(repoName, strings.Repeat(" ", 45-len(repoName)), err.Error())
 }
 
-func writeRow(repoName, message string) string {
+func writeRow(repoName, message string, oneline bool) string {
+	if oneline {
+		return fmt.Sprint(repoName, strings.Repeat(" ", 45-len(repoName)), message)
+	}
 	return fmt.Sprintln(repoName, strings.Repeat(" ", 45-len(repoName)), message)
 }
 

--- a/cmd/gdiv/main.go
+++ b/cmd/gdiv/main.go
@@ -58,11 +58,11 @@ func main() {
 func writeDiff(repoName string, diff Diff, cfg cfg.Config) string {
 	sb := new(strings.Builder)
 	msg := []string{}
-	if cfg.AheadOnly || !cfg.BehindOnly {
+	if cfg.AheadOnly || (!cfg.AheadOnly && !cfg.BehindOnly) {
 		msg = append(msg, fmt.Sprintf("ahead by %d", diff.Ahead))
 	}
-	if !cfg.AheadOnly || cfg.BehindOnly {
-		msg = append(msg, fmt.Sprintf("ahead by %d", diff.Ahead))
+	if cfg.BehindOnly || (!cfg.AheadOnly && !cfg.BehindOnly) {
+		msg = append(msg, fmt.Sprintf("behind by %d", diff.Behind))
 	}
 	sb.WriteString(writeRow(repoName, strings.Join(msg, ", ")))
 	sb.WriteString(writeRow("", fmt.Sprintf("  %s -> %s", diff.BaseHash, diff.HeadHash)))
@@ -72,10 +72,10 @@ func writeDiff(repoName string, diff Diff, cfg cfg.Config) string {
 func writeShort(repoName string, diff Diff, cfg cfg.Config) string {
 	sb := new(strings.Builder)
 	msg := []string{}
-	if cfg.AheadOnly || !cfg.BehindOnly {
+	if cfg.AheadOnly || (!cfg.AheadOnly && !cfg.BehindOnly) {
 		msg = append(msg, fmt.Sprintf("ahead by %d", diff.Ahead))
 	}
-	if !cfg.AheadOnly || cfg.BehindOnly {
+	if cfg.BehindOnly || (!cfg.AheadOnly && !cfg.BehindOnly) {
 		msg = append(msg, fmt.Sprintf("behind by %d", diff.Behind))
 	}
 	msg = append(msg, diff.URL)


### PR DESCRIPTION
doc: tell users where put options
lint: errors should be lowercase
bug: only show the selected ahead or behind
bug: copy past of  diff.Ahead