### PR TITLE
feat: default to ignoring archived repos

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -13,17 +13,17 @@ import (
 const defaultPath = "~/.gdivpat"
 
 type cmdArgs struct {
-	pat, patPath           string
-	org, head, base        string
-	aheadOnly, behindOnly  bool
-	all, help, short, json bool
+	pat, patPath                         string
+	org, head, base                      string
+	aheadOnly, behindOnly                bool
+	all, help, short, json, inclArchived bool
 }
 
 type Config struct {
-	GitPat                string
-	Org, Head, Base       string
-	AheadOnly, BehindOnly bool
-	ShowAll, Short, Json  bool
+	GitPat                             string
+	Org, Head, Base                    string
+	AheadOnly, BehindOnly              bool
+	ShowAll, Short, Json, InclArchived bool
 }
 
 func LoadArgs() (cfg Config, err error) {
@@ -41,6 +41,7 @@ func LoadArgs() (cfg Config, err error) {
 	flag.BoolVar(&cmd.behindOnly, "behind", false, "Show only the behindBy number.")
 	flag.BoolVar(&cmd.short, "s", false, "Show a short version of the output.")
 	flag.BoolVar(&cmd.json, "json", false, "Output as json.")
+	flag.BoolVar(&cmd.inclArchived, "include-archived", false, "Include repos that are archived")
 
 	flag.Parse()
 
@@ -60,15 +61,16 @@ func LoadArgs() (cfg Config, err error) {
 	}
 
 	cfg = Config{
-		GitPat:     cmd.pat,
-		Org:        args[0],
-		Base:       args[1],
-		Head:       args[2],
-		ShowAll:    cmd.all,
-		Short:      cmd.short,
-		AheadOnly:  cmd.aheadOnly,
-		BehindOnly: cmd.behindOnly,
-		Json:       cmd.json,
+		GitPat:       cmd.pat,
+		Org:          args[0],
+		Base:         args[1],
+		Head:         args[2],
+		ShowAll:      cmd.all,
+		Short:        cmd.short,
+		AheadOnly:    cmd.aheadOnly,
+		BehindOnly:   cmd.behindOnly,
+		Json:         cmd.json,
+		InclArchived: cmd.inclArchived,
 	}
 
 	if cfg.GitPat == "" {

--- a/cmd/gdiv/main.go
+++ b/cmd/gdiv/main.go
@@ -21,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 	client := newGitClient(cfg.GitPat)
-	repos, err := client.getRepos(cfg.Org)
+	repos, err := client.getRepos(cfg.Org, cfg.InclArchived)
 	if err != nil {
 		panic(err)
 	}
@@ -140,7 +140,7 @@ func newGitClient(token string) gitClient {
 	return gitClient{client}
 }
 
-func (cli gitClient) getRepos(org string) ([]string, error) {
+func (cli gitClient) getRepos(org string, ia bool) ([]string, error) {
 	var names []string
 	opt := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
@@ -152,6 +152,9 @@ func (cli gitClient) getRepos(org string) ([]string, error) {
 			return names, err
 		}
 		for _, r := range repos {
+			if r.GetArchived() && !ia {
+				continue
+			}
 			names = append(names, r.GetName())
 		}
 		if resp.NextPage == 0 {


### PR DESCRIPTION
If a repo is archived then ignore by default as changes can no longer be made in a read-only status